### PR TITLE
mvn 3.1 or higher uses a different slf4j that doesn't have this call

### DIFF
--- a/src/main/java/com/github/klieber/phantomjs/mojo/AbstractPhantomJsMojo.java
+++ b/src/main/java/com/github/klieber/phantomjs/mojo/AbstractPhantomJsMojo.java
@@ -70,7 +70,12 @@ public abstract class AbstractPhantomJsMojo extends AbstractMojo {
   private MavenProject mavenProject;
 
   public final void execute() throws MojoFailureException {
-    StaticLoggerBinder.getSingleton().setMavenLog(getLog());
+    try{
+        StaticLoggerBinder.getSingleton().setMavenLog(getLog());
+    } catch (NoClassDefFoundError e){
+        getLog().error("Failed to setup mvn log, this is ok if you're using mvn >= 3.1");
+        getLog().error(System.getProperty("plugin.artifacts"));
+    }
     if (!skip) {
       this.run();
     }


### PR DESCRIPTION
We couldn't get this plugin to work on mvn >= 3.1. This fixes the problem, but it might not be the idea fix. 
