### PR TITLE
Add a new goal for downloading and deploying archives to central

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+if [ ! "$1" ]; then
+  echo 'please provide the version'
+  exit 1;
+fi
+
+mkdir -p target/binary-deployer
+cd target/binary-deployer
+
+groupId=com.github.klieber
+artifactId=phantomjs
+version=$1
+
+baseUrl="https://bitbucket.org/ariya/phantomjs/downloads"
+#baseUrl="https://phantomjs.googlecode.com/files"
+
+sonatypeUrl="https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+repoId=sonatype-nexus-staging
+
+deploy() {
+  classifier=$1
+  extension=$2
+  filename="$artifactId-$version-$classifier.$extension"
+  echo "deploying $baseUrl/$filename"
+
+  wget "$baseUrl/$filename" && mvn gpg:sign-and-deploy-file -Durl=$sonatypeUrl -DrepositoryId=$repoId -Dfile=$filename -DgroupId=$groupId -DartifactId=$artifactId -Dversion=$version -Dpackaging=$extension -Dclassifier=$classifier -DgeneratePom=false
+}
+
+deploy "windows" "zip"
+deploy "macosx" "zip"
+deploy "linux-x86_64" "tar.bz2"
+deploy "linux-i686" "tar.bz2"


### PR DESCRIPTION
The 0.4 release will have the ability to install phantomjs from archives stored in maven central rather than directly from google code/bitbucket.  While originally the plan was to utilize the `arquillian-phantom-binary` project for this feature I think it would be better not to rely on that project.  Currently, they only have 1.9.0, 1.9.1, and 1.9.2 [available](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.jboss.arquillian.extension%22%20AND%20a%3A%22arquillian-phantom-binary%22).

So, I want to add a new goal that will download the archives for a specific phantomjs version and then deploy them to central under the `com.github.klieber` groupId.  This goal will mainly just be used by me when a new version of phantomjs comes out.
