### PR TITLE
Expand capabilities of the enforceVersion parameter

### DIFF
--- a/phantomjs-maven-core/src/main/java/com/github/klieber/phantomjs/locate/PhantomJsLocatorOptions.java
+++ b/phantomjs-maven-core/src/main/java/com/github/klieber/phantomjs/locate/PhantomJsLocatorOptions.java
@@ -12,7 +12,7 @@ public interface PhantomJsLocatorOptions {
   Source getSource();
   String getVersion();
   boolean isCheckSystemPath();
-  boolean isEnforceVersion();
+  String getEnforceVersion();
   String getBaseUrl();
   File getOutputDirectory();
 }

--- a/phantomjs-maven-core/src/main/java/com/github/klieber/phantomjs/resolve/PhantomJsBinaryResolver.java
+++ b/phantomjs-maven-core/src/main/java/com/github/klieber/phantomjs/resolve/PhantomJsBinaryResolver.java
@@ -22,6 +22,7 @@ package com.github.klieber.phantomjs.resolve;
 
 import com.github.klieber.phantomjs.exec.ExecutionException;
 import com.github.klieber.phantomjs.exec.PhantomJsProcessBuilder;
+import com.github.klieber.phantomjs.util.VersionUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,12 +46,10 @@ public class PhantomJsBinaryResolver implements BinaryResolver {
     "phantomjs.exe"
   );
 
-  private final String version;
-  private final boolean enforceVersion;
+  private final String versionSpec;
 
-  public PhantomJsBinaryResolver(String version, boolean enforceVersion) {
-    this.version = version;
-    this.enforceVersion = enforceVersion;
+  public PhantomJsBinaryResolver(String versionSpec) {
+    this.versionSpec = versionSpec;
   }
 
   @Override
@@ -69,9 +68,10 @@ public class PhantomJsBinaryResolver implements BinaryResolver {
     File file = new File(path, binary);
     if (file.exists()) {
       String versionString = getVersion(file.getAbsolutePath());
-      if (versionString != null && (!this.enforceVersion || this.version.equals(versionString))) {
-        LOGGER.info(FOUND_PHANTOMJS,versionString,binary);
-        return file.getAbsolutePath();
+      if (versionString != null && VersionUtil.isWithin(versionString, this.versionSpec)) {
+        String absolutePath = file.getAbsolutePath();
+        LOGGER.info(FOUND_PHANTOMJS,versionString,absolutePath);
+        return absolutePath;
       }
     }
     return null;
@@ -94,5 +94,4 @@ public class PhantomJsBinaryResolver implements BinaryResolver {
     }
     return null;
   }
-
 }

--- a/phantomjs-maven-core/src/main/java/com/github/klieber/phantomjs/util/VersionUtil.java
+++ b/phantomjs-maven-core/src/main/java/com/github/klieber/phantomjs/util/VersionUtil.java
@@ -20,9 +20,17 @@
  */
 package com.github.klieber.phantomjs.util;
 
+import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class VersionUtil {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(VersionUtil.class);
 
   public static int compare(String versionA, String versionB) {
     if (versionA == versionB) {
@@ -45,7 +53,63 @@ public class VersionUtil {
     return compare(versionA, versionB) < 0;
   }
 
+  public static boolean isGreaterThanOrEqualTo(String versionA, String versionB) {
+    return !VersionUtil.isLessThan(versionA, versionB);
+  }
+
+  public static boolean isLessThanOrEqualTo(String versionA, String versionB) {
+    return !VersionUtil.isGreaterThan(versionA, versionB);
+  }
+
   public static boolean isEqualTo(String versionA, String versionB) {
     return compare(versionA, versionB) == 0;
+  }
+
+  public static int compare(ArtifactVersion versionA, ArtifactVersion versionB) {
+    if (versionA == versionB) {
+      return 0;
+    }
+    if (versionA == null) {
+      return -1;
+    }
+    if (versionB == null) {
+      return 1;
+    }
+    return versionA.compareTo(versionB);
+  }
+
+  public static boolean isGreaterThanOrEqualTo(ArtifactVersion versionA, ArtifactVersion versionB) {
+    return !VersionUtil.isLessThan(versionA, versionB);
+  }
+
+  public static boolean isLessThan(ArtifactVersion versionA, ArtifactVersion versionB) {
+    return compare(versionA, versionB) < 0;
+  }
+
+  public static boolean isLessThanOrEqualTo(ArtifactVersion versionA, ArtifactVersion versionB) {
+    return !VersionUtil.isGreaterThan(versionA, versionB);
+  }
+
+  public static boolean isGreaterThan(ArtifactVersion versionA, ArtifactVersion versionB) {
+    return compare(versionA, versionB) > 0;
+  }
+
+  public static boolean isWithin(String version, VersionRange versionRange) {
+    ArtifactVersion artifactVersion = new DefaultArtifactVersion(version);
+    ArtifactVersion recommendedVersion = versionRange.getRecommendedVersion();
+    // treat recommended version as minimum version
+    return recommendedVersion != null ?
+        VersionUtil.isLessThanOrEqualTo(recommendedVersion, artifactVersion) :
+        versionRange.containsVersion(artifactVersion);
+  }
+
+  public static boolean isWithin(String version, String versionSpec) {
+    boolean within = false;
+    try {
+      return VersionUtil.isWithin(version, VersionRange.createFromVersionSpec(versionSpec));
+    } catch (InvalidVersionSpecificationException e) {
+      LOGGER.warn("Invalid version specification: {}", versionSpec);
+    }
+    return within;
   }
 }

--- a/phantomjs-maven-core/src/test/java/com/github/klieber/phantomjs/resolve/PhantomJsBinaryResolverTest.java
+++ b/phantomjs-maven-core/src/test/java/com/github/klieber/phantomjs/resolve/PhantomJsBinaryResolverTest.java
@@ -76,15 +76,11 @@ public class PhantomJsBinaryResolverTest {
 
   @Test
   public void testShouldResolveBinWrongVersion() {
-    assertNull(getResolver("1.9.2", true).resolve(phantomJsHome.getParent()));
+    assertNull(getResolver("1.9.2").resolve(phantomJsHome.getParent()));
   }
 
   private PhantomJsBinaryResolver getResolver(String version) {
-    return getResolver(version, false);
-  }
-
-  private PhantomJsBinaryResolver getResolver(String version, boolean enforce) {
-    return new PhantomJsBinaryResolver(version, enforce);
+    return new PhantomJsBinaryResolver(version);
   }
 
   private void assumeUnixOs() {

--- a/phantomjs-maven-plugin/src/main/java/com/github/klieber/phantomjs/mojo/InstallPhantomJsMojo.java
+++ b/phantomjs-maven-plugin/src/main/java/com/github/klieber/phantomjs/mojo/InstallPhantomJsMojo.java
@@ -85,23 +85,25 @@ public class InstallPhantomJsMojo extends AbstractPhantomJsMojo implements Phant
    * @since 0.2
    */
   @Parameter(
-      defaultValue = "false",
+      defaultValue = "true",
       property = "phantomjs.checkSystemPath",
       required = true
   )
   private boolean checkSystemPath;
 
   /**
-   * Require that the correct version of phantomjs is on the system path.
+   * Require that the correct version of phantomjs is on the system path. You may either specify a boolean value
+   * or starting with version 0.7 of the plugin you can also specify a version range following the same syntax
+   * as the <a href="http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html">Maven Enforcer Plugin</a>.
    *
    * @since 0.2
    */
   @Parameter(
       defaultValue = "true",
       property = "phantomjs.enforceVersion",
-      required = true
+      required = false
   )
-  private boolean enforceVersion;
+  private String enforceVersion;
 
   /**
    * <p>The download source for the phantomjs binary.</p>
@@ -154,7 +156,7 @@ public class InstallPhantomJsMojo extends AbstractPhantomJsMojo implements Phant
   }
 
   @Override
-  public boolean isEnforceVersion() {
+  public String getEnforceVersion() {
     return this.enforceVersion;
   }
 


### PR DESCRIPTION
Extend the `enforceVersion` parameter to allow a syntax similar to maven's for [specifying a version range](http://books.sonatype.com/mvnref-book/reference/pom-relationships-sect-project-dependencies.html#pom-relationships-sect-version-ranges).  Then we could enforce that the version just fall within that range.

For instance, this says to check the system path for phantomjs and if it is found and the version is greater than 1.9.0 than use that version, otherwise, download version 1.9.2:

```xml
<configuration>
  <version>1.9.2</version>
  <checkSystemPath>true</checkSystemPath> <!-- default is false -->
  <enforceVersion>[1.9.0,]</enforceVersion> <!-- default is ${phantomjs.version}, only applies when checkSystemPath is true -->
</configuration>
```