### PR TITLE
Use maven-artifact instead of maven-core

### DIFF
--- a/phantomjs-maven-core/pom.xml
+++ b/phantomjs-maven-core/pom.xml
@@ -15,7 +15,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
+      <artifactId>maven-artifact</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
         <version>3.2.1</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-artifact</artifactId>
+        <version>3.0.5</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
         <version>3.4</version>


### PR DESCRIPTION
This will make it so the phantomjs core is lighter and won't download all of maven core just to use the versioning stuff in the maven-artifact piece