### PR TITLE
Use maven-artifact instead of maven-core for phantomjs-maven-core

### DIFF
--- a/phantomjs-maven-core/pom.xml
+++ b/phantomjs-maven-core/pom.xml
@@ -15,7 +15,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
+      <artifactId>maven-artifact</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/phantomjs-maven-plugin/pom.xml
+++ b/phantomjs-maven-plugin/pom.xml
@@ -20,6 +20,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
         <version>3.2.1</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-artifact</artifactId>
+        <version>3.0.5</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
         <version>3.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <truezip.version>7.7.8</truezip.version>
     <junit.version>4.12</junit.version>
+    <maven.version>3.2.1</maven.version>
   </properties>
 
   <prerequisites>
@@ -97,12 +98,12 @@
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
-        <version>3.2.1</version>
+        <version>${maven.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-core</artifactId>
-        <version>3.2.1</version>
+        <version>${maven.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Change the dependencies of phantomjs-maven-core so that it doesn't require maven-core to work. This is beneficial because it allows the use of the phantomjs-maven-core outside of the maven plugin itself (with some work to fake the repository system stuff).
