### PR TITLE
add systemPropertyVariables phantomjs.binary.path

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Example using in a JUnit test:
         <configuration>
           <systemPropertyVariables>
             <phantomjs.binary>${phantomjs.binary}</phantomjs.binary>
+            <phantomjs.binary.path>${phantomjs.binary}</phantomjs.binary.path>
           </systemPropertyVariables>
         </configuration>
       </plugin>


### PR DESCRIPTION
Adds another system property variable to the JUnit example.
phantomjs.binary.path is the system property that GhostDriver uses to locate the phantomjs binary.
I guess this is one of the main use cases for this plugin in combination with JUnit.
